### PR TITLE
feat: Add GitHub Actions for CI and Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y gcc-arm-none-eabi make
 
+    - name: Build libopencm3
+      run: make -C libopencm3
+
     - name: Build firmware
       run: make
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,10 @@ jobs:
     - name: Build firmware
       run: make
 
-    - name: List files in workspace
-      run: ls -R
-
     - name: Archive firmware
       uses: actions/upload-artifact@v4
       with:
         name: firmware
         path: |
-          bin/stm32-slcan.bin
-          bin/stm32-slcan.elf
+          stm32-slcan.bin
+          stm32-slcan.elf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-arm-none-eabi make
+
+    - name: Build firmware
+      run: make
+
+    - name: Archive firmware
+      uses: actions/upload-artifact@v4
+      with:
+        name: firmware
+        path: |
+          bin/stm32-slcan.bin
+          bin/stm32-slcan.elf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
     - name: Build firmware
       run: make
 
+    - name: List files in workspace
+      run: ls -R
+
     - name: Archive firmware
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-arm-none-eabi make
 
+      - name: Build libopencm3
+        run: make -C libopencm3
+
       - name: Build firmware
         run: make
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-none-eabi make
+
+      - name: Build firmware
+        run: make
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            bin/stm32-slcan.bin
+            bin/stm32-slcan.elf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,5 +30,5 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            bin/stm32-slcan.bin
-            bin/stm32-slcan.elf
+            stm32-slcan.bin
+            stm32-slcan.elf


### PR DESCRIPTION
This change introduces two GitHub Actions workflows to automate the build and release process for the stm32-slcan firmware.

The `ci.yml` workflow is triggered on every push to the `master` branch and on pull requests. It builds the firmware and uploads the resulting binaries as artifacts. This will help ensure that the firmware always compiles correctly.

The `release.yml` workflow is triggered when a new tag is pushed (e.g., `v1.0.0`). It builds the firmware and then creates a GitHub Release, attaching the compiled `.bin` and `.elf` files as release assets. This automates the process of releasing new versions of the firmware.